### PR TITLE
fix to pick up if num of other hhm is None not none

### DIFF
--- a/r/version_1/dm10_clean_household_v1.R
+++ b/r/version_1/dm10_clean_household_v1.R
@@ -85,7 +85,7 @@ options(warn = -1)
 
 dt[, hh_size_int := as.numeric(hh_size) + 1]
 dt[, hh_size_int := as.numeric(hh_size)]
-dt[hh_size == "none", hh_size_int := 1]
+dt[tolower(hh_size) == "none", hh_size_int := 0]
 dt[hh_size == "11 or more", hh_size_int := 12]
 dt[hh_size_int == 1, hh_size_group := "1",]
 dt[hh_size_int == 2, hh_size_group := "2",]


### PR DESCRIPTION
The question was "Q20. Not including you, how many other people live in your household?". Respondents could answer "None", which is not getting picked up correctly. 
This does not affect the other versions as the question has changed to "Q20. Including you, ..."